### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 This is a fork of Redirect cleaner orginally developed by Alexander Bergmann <myaddons@gmx.de>
 
 RedirectCleaner cleans Redirects from Links
+
+Modes:
+* Whitelist - Clean all redirects except on sites matching the Whitelist entries.
+* Blacklist - Allow all redirects except on sites matching the Blacklist entries.
+
+
+Whitelist/Blacklist Format Options:
+* Comma Separated List - A list of domain names separated by commas. To use a comma separated list you must uncheck the "Regular Expression" checkbox.
+* Regular Expression - An expression used for pattern matching against the full url. See [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) for more information. To use a regular expression you must check the "Regular Expression" checkbox.

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -357,14 +357,18 @@ var RedirectCleaner = {
 		
 		if(RedirectCleaner.prefs.regexp) {
 			
-			try {
-				
-				var regexp = new RegExp(RedirectCleaner.prefs.whitelist, "i");
-				if(regexp.source && regexp.test(spec)) { return true; }
-				
-			} catch(e) {
-				
-				Services.console.logStringMessage("RedirectCleaner: Error" + "\n" + e);
+			if(RedirectCleaner.prefs.whitelist != "") {
+			
+				try {
+					
+					var regexp = new RegExp(RedirectCleaner.prefs.whitelist, "i");
+					if(regexp.source && regexp.test(spec)) { return true; }
+					
+				} catch(e) {
+					
+					Services.console.logStringMessage("RedirectCleaner: Error" + "\n" + e);
+					
+				}
 				
 			}
 			
@@ -376,7 +380,7 @@ var RedirectCleaner = {
 				var items = RedirectCleaner.prefs.whitelist.split(",").sort();
 				for(var i = 0; i < items.length; i++) {
 					
-					var item = items[i];
+					var item = items[i].trim();
 					if(item && host.indexOf(item) != -1) { return true; }
 					
 				}
@@ -395,15 +399,19 @@ var RedirectCleaner = {
 		
 		if(RedirectCleaner.prefs.regexp) {
 			
-			try {
-				
-				var regexp = new RegExp(RedirectCleaner.prefs.blacklist, "i");
-				if(regexp.source && regexp.test(spec)) { return true; }
-				
-			} catch(e) {
-				
-				Services.console.logStringMessage("RedirectCleaner: Error" + "\n" + e);
-				
+			if(RedirectCleaner.prefs.blacklist != "") {
+			
+				try {
+					
+					var regexp = new RegExp(RedirectCleaner.prefs.blacklist, "i");
+					if(regexp.source && regexp.test(spec)) { return true; }
+					
+				} catch(e) {
+					
+					Services.console.logStringMessage("RedirectCleaner: Error" + "\n" + e);
+					
+				}
+			
 			}
 			
 		}
@@ -414,7 +422,7 @@ var RedirectCleaner = {
 				var items = RedirectCleaner.prefs.blacklist.split(",").sort();
 				for(var i = 0; i < items.length; i++) {
 					
-					var item = items[i];
+					var item = items[i].trim();
 					if(item && host.indexOf(item) != -1) { return true; }
 					
 				}

--- a/content/history.xul
+++ b/content/history.xul
@@ -7,7 +7,7 @@
 	id="redirectcleaner"
 	xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
 	title="RedirectCleaner"
-	buttons="help"
+	buttons="help,extra1"
 	ondialogaccept=""
 	ondialogcancel=""
 	ondialoghelp="help()"

--- a/content/history.xul
+++ b/content/history.xul
@@ -11,15 +11,23 @@
 	ondialogaccept=""
 	ondialogcancel=""
 	ondialoghelp="help()"
+	buttonlabelextra1="&redirectcleaner.history.options;"
+	ondialogextra1="options()"
 	onload=""
 	style="background: white;">
 	
 	<script type="application/x-javascript">
 		<![CDATA[
+		Components.utils.import('resource://gre/modules/Services.jsm');
+		
 		function help() {
 			
 			window.openDialog("chrome://redirectcleaner/content/about.xul", "_blank", "chrome,dialog,modal,centerscreen", null);
 			
+		}
+		
+		function options() {
+			Services.wm.getMostRecentWindow('navigator:browser').BrowserOpenAddonsMgr('addons://detail/redirectcleaner@example.org/preferences');
 		}
 		]]>
 	</script>

--- a/locale/en-US/redirectcleaner.dtd
+++ b/locale/en-US/redirectcleaner.dtd
@@ -5,6 +5,7 @@
 <!ENTITY redirectcleaner.history.history "History">
 <!ENTITY redirectcleaner.history.original "Original Link">
 <!ENTITY redirectcleaner.history.clean "Clean Link">
+<!ENTITY redirectcleaner.history.options "Options">
 <!ENTITY redirectcleaner.options.mode "Mode">
 <!ENTITY redirectcleaner.options.whitelist "Whitelist">
 <!ENTITY redirectcleaner.options.blacklist "Blacklist">


### PR DESCRIPTION
Changes:
1. Now trims leading/trailing spaces from items split out of the non-regexp whitelist and blacklist (now supports "item1, item2" as well as "item1,item2").
2. Added checks for empty whitelist/blacklist strings when using regexp mode since running a test on an undefined/empty pattern always returns true. This issue reversed the intended behavior of the two modes when the regexp option was selected and the list box for the active mode was empty (regexp whitelist mode ignored everything and regexp blacklist mode cleaned everything).
3. Added an options button to cleaning history menu and a localization entry for the button name.
4. Added Readme documentation for options.